### PR TITLE
add support datetimeoffset type which uses in microsoft webapi odata …

### DIFF
--- a/src/odatavalue.js
+++ b/src/odatavalue.js
@@ -29,6 +29,14 @@ factory('$odataValue', [
         		return date.getFullYear() + "-" + ("0" + (date.getMonth() + 1)).slice(-2) + "-" + ("0" + date.getDate()).slice(-2) + "T" + ("0" + date.getHours()).slice(-2) + ":" + ("0" + date.getMinutes()).slice(-2)+':'+("0" + date.getSeconds()).slice(-2) + "Z";
         	}
         };
+		
+		var generateDateOffset = function (date, isOdataV4) {
+            if (!isOdataV4) {
+                return "datetimeoffset'" + date.getFullYear() + "-" + ("0" + (date.getMonth() + 1)).slice(-2) + "-" + ("0" + date.getDate()).slice(-2) + "T" + ("0" + date.getHours()).slice(-2) + ":" + ("0" + date.getMinutes()).slice(-2) + ':' + ("0" + date.getSeconds()).slice(-2) + "'";
+            } else {
+                return date.getFullYear() + "-" + ("0" + (date.getMonth() + 1)).slice(-2) + "-" + ("0" + date.getDate()).slice(-2) + "T" + ("0" + date.getHours()).slice(-2) + ":" + ("0" + date.getMinutes()).slice(-2) + ':' + ("0" + date.getSeconds()).slice(-2) + "Z";
+            }
+        };
 
         ODataValue.prototype.executeWithUndefinedType = function(isOdataV4) {
             if (angular.isString(this.value)) {
@@ -67,6 +75,8 @@ factory('$odataValue', [
 	        		return this.value.getTime()+"d";
 	        	}else if(this.type.toLowerCase() === "datetime"){
 	        		return generateDate(this.value,isOdataV4);
+	        	} else if (this.type.toLowerCase() === "datetimeoffset") {
+	        	    return generateDateOffset(new Date(this.value), isOdataV4);					
 	        	}else if(this.type.toLowerCase()==="string"){
 	        		return "'"+this.value.toISOString()+"'";
 	        	}else {
@@ -78,6 +88,8 @@ factory('$odataValue', [
 	        		return "guid'"+this.value+"'";
 	        	}else if(this.type.toLowerCase() === "datetime"){
 	        		return generateDate(new Date(this.value),isOdataV4);
+	        	} else if (this.type.toLowerCase() === "datetimeoffset") {
+	        	    return generateDateOffset(new Date(this.value), isOdataV4);					
 	        	}else if(this.type.toLowerCase() === "single"){
 	        		return parseFloat(this.value)+"f";
 	        	}else if(this.type.toLowerCase() === "double"){


### PR DESCRIPTION
add support datetimeoffset type which uses in microsoft webapi odata implementation

code like this:
$odataresource('url').odata().filter('SomeDate', '>=', new $odata.Value(fromFilter,'DateTime'));

not working in odata controller implementation like this:

using System.Data.Entity;
using System.Linq;
using System.Web.Http;
using System.Web.Http.OData;
using System.Web.Http.OData.Query;

public class SomeController : ODataController
{
  private IQueryable<SomeEntity> _q;

  public SomeController(IQueryable<SomeEntity> q)
  {
    _q = q;
  }

  public IHttpActionResult Get(ODataQueryOptions<SomeEntity> query)
  {
    var result = query.ApplyTo(q) as IQueryable<SomeEntity>;
    return Ok(result.ToArray());
  }
}

I give error:
A binary operator with incompatible types was detected. Found operand types 'Edm.DateTimeOffset' and 'Edm.DateTime' for operator kind 'GreaterThanOrEqual'.
