### PR TITLE
Update odataresources.js

### DIFF
--- a/build/odataresources.js
+++ b/build/odataresources.js
@@ -522,6 +522,11 @@ factory('$odataProvider', ['$odataOperators', '$odataBinaryOperation', '$odataPr
             if (queryString.length > 0) {
                 queryString = "?" + queryString;
             }
+	    var pattern = /^[0-9]*$/;
+
+	    if (pattern.test(data)) {
+		    return this.callback("(" + data + ")" + queryString, success, error, true);
+	    }
             return this.callback("(" + data + ")" + queryString, success, error, true);
         };
 


### PR DESCRIPTION
Allow the .get method to also pass through strings enclosed in single quotes. 

The new return part of the function looks like this:
 var pattern = /^[0-9]*$/;

```
    if (pattern.test(data)) {
        return this.callback("(" + data + ")" + queryString, success, error, true);
    }
        return this.callback("(" + data + ")" + queryString, success, error, true);
```
